### PR TITLE
fix speaker info

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -2005,7 +2005,7 @@
             {
                 "no": 30,
                 "en_speaker": "Warren",
-                "ja_speaker": "オリバー",
+                "ja_speaker": "ウォーレン",
                 "en_sentence": "We have to figure out ways to reduce turnover and increase employee retention.",
                 "ja_sentence": "どうにかして従業員の離職率を低めて、定着率を上げる方法を見つけないといけないな。"
             },
@@ -4256,7 +4256,7 @@
             {
                 "no": 16,
                 "ja_speaker": "ケリー",
-                "en_speaker": "Julie",
+                "en_speaker": "Kelly",
                 "ja_sentence": "美味しそう！",
                 "en_sentence": "That looks good."
             },
@@ -6385,7 +6385,7 @@
             },
             {
                 "no": 25,
-                "en_speaker": "Mr. Matsunaga",
+                "en_speaker": "Ms. Matsunaga",
                 "ja_speaker": "松永さん",
                 "en_sentence": "Ok, hope to hear a good news from you soon.",
                 "ja_sentence": "承知いたしました、良いニュースが入るのを楽しみにしています。"

--- a/test.json
+++ b/test.json
@@ -127,14 +127,14 @@
             {
                 "no": 18,
                 "en_speaker": "Mr. Wayne Willis",
-                "ja_speaker": "ウェインウィリスさん",
+                "ja_speaker": "ウェイン ウィリスさん",
                 "en_sentence": "Yes, so we can control the ship loading and schedule.",
                 "ja_sentence": "そう、出荷量やスケジュールも管理できます。"
             },
             {
                 "no": 19,
                 "en_speaker": "Mr. Wayne Willis",
-                "ja_speaker": "ウェインウィリスさん",
+                "ja_speaker": "ウェイン ウィリスさん",
                 "en_sentence": "Having control over the supply chain is definitely helpful.",
                 "ja_sentence": "サプライチェーンを管理できるのはとても助かります。"
             },
@@ -3588,7 +3588,7 @@
             {
                 "no": 2,
                 "en_speaker": "Mr. Sam Lee",
-                "ja_speaker": "サム リーさん",
+                "ja_speaker": "サム リー さん",
                 "en_sentence": "Thank you for coming to our office today.",
                 "ja_sentence": "今日はうちのオフィスまで来て頂いて、ありがとうございます。"
             },
@@ -7975,7 +7975,7 @@
             {
                 "no": 19,
                 "en_speaker": "Ben",
-                "ja_speaker": "クリスチャン",
+                "ja_speaker": "ベン",
                 "en_sentence": "I'd prefer to visit them in person and check out their equipment before making an order through a faceless computer screen.",
                 "ja_sentence": "PCのスクリーンで無人注文するよりも、実際に担当者に会って装置など確認してから注文する方がしっくりくるな。"
             },
@@ -7996,7 +7996,7 @@
             {
                 "no": 22,
                 "en_speaker": "Ben",
-                "ja_speaker": "クリスチャン",
+                "ja_speaker": "ベン",
                 "en_sentence": "Thanks Christian.",
                 "ja_sentence": "クリスチャン、ありがとう。"
             }


### PR DESCRIPTION
# 話者情報の修正

翻訳の研究をしている者です。
対話翻訳という興味深いテーマでコーパスを提供いただきありがとうございます。

対話を話者ごとに分離しようとしたところ、en_speakerとja_speakerで分けた場合に異なる分かれ方になる場合があることに気がつきました。
原因としては主に以下の6つです。
- en_speakerとja_speakerで対応が取れていない（"Warren"と"オリバー"など）
- ja_speakerで苗字と名前の間に空白が入っている場合と入っていない場合がある（"ウェインウィリスさん"と"ウェイン ウィリスさん"など）
- 同じはずの話者の性別が違う（"Mr. Matsunaga"と"Ms. Matsunaga"など）
- 半角と全角の違いのため同じ話者が違う話者になっている（"参加者1"と"参加者１"など）
- スペルミス（"エリカ"と"エリア"など）
- 「さん」が欠けている、または余分に付いている（"カーバー"と"カーバーさん"など）

以上の観点で、コーパス全体を見直し可能な限り文脈を読んで手動で修正を行いました。
ほとんどのケースで正しい修正は明らかでしたが、 `train.json` で以下のように不明確な点がいくつかありましたので、特にご確認いただければ幸いです。
1. id: 190315_E012_10, no: 24-26
 en_speakerが"Betty"、ja_speakerが"ホテルのスタッフ"となっている。文脈からベティはホテルのスタッフであり、それ以前に出てきている"ベティ"と同一人物であると考えられるため、ja_speakerを"ベティ"に修正した。
1. id: 190315_E011_14, no.3
 en_speakerが"Ms. Julia Kramer"、ja_speakerが"アンジェラ カミングスさん"となっていた。文脈上どちらが話していても違和感はないように思われる。original_languageがenであったためja_speakerを"ジュリア クレーマーさん"に変更した。
1. id: 190315_E010_01 no.15
 en_speakerが"Mr. Maehara Shinya"、ja_speakerが"サム リーさん"となっていた。文脈と発話の内容から判断して前原さんの発話だと考えられるが、日本語訳の"ビジネスチャンスを探れるかもしれませんね"の「ね」は対話相手に対する同意を表すような表現であり、ここで現れるのは不自然であるように思われる。訳は修正せず、ja_speakerを"前原 信也さん"とするよう修正した。

また、話者の修正とは関係ありませんが、以下の文のreailは明らかにretailのスペルミスであると判断し修正しました。
- id: 190315_E012_05, no: 33

以上、確認・修正いただければと存じます。
よろしくお願いいたします。