### PR TITLE
fix speaker info again

### DIFF
--- a/dev.json
+++ b/dev.json
@@ -6385,7 +6385,7 @@
             },
             {
                 "no": 25,
-                "en_speaker": "Mr. Matsunaga",
+                "en_speaker": "Ms. Matsunaga",
                 "ja_speaker": "松永さん",
                 "en_sentence": "Ok, hope to hear a good news from you soon.",
                 "ja_sentence": "承知いたしました、良いニュースが入るのを楽しみにしています。"


### PR DESCRIPTION
# 話者情報の再修正

度々失礼します。
以前話者情報修正のプルリクエストをした者です。

話者情報の修正及びスペルミスの修正をいただき、ありがとうございます。
ほとんどは修正できていたのですが、いくつか修正が反映されていない部分がありましたので再度プルリクエストを開かせていただきました。

修正した点としましては以下の5点になります。
1. en_speaker の話者の性別の不一致 (dev.json line 6388, train.json line 77136, 77143, 99651, 99658, and 99728)
2. ja_speaker の全角/半角の不一致 (train.json line 55926 - 56017)
3. スペルミス (train.json line 62460, 78972, 79182)
4. 空白の有無による話者の不一致 (train.json line 79730, 99686)
5. 文脈から判断して、話者が間違って修正されたと考えられるもの (train.json line 86412-86413, 86545-86546, 103734-103735, and 103748-103749)

なお、話者が一致するかどうかにつきましては、[話者ごとにjsonを分けるスクリプト](https://gist.github.com/cromz22/0f2435ac4136f97b6556c0aa8b7cad41)を用いて、`ja_speaker` で分けた場合と `en_speaker` で分けた場合との diff をとって検出しています。

よろしくお願いいたします。